### PR TITLE
fix: `pkg_subpath` in `FetchStep` pointing to wrong place & header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
+zig-pkg
 zig-out
 versions-cache.json

--- a/FetchStep.zig
+++ b/FetchStep.zig
@@ -110,12 +110,12 @@ fn make(step: *Step, _: Step.MakeOptions) !void {
     }
 
     // Package is stored in <global_cache>/p/<hash>
-    const pkg_subpath = try std.fs.path.join(arena, &.{ "p", pkg_hash });
+    const pkg_subpath = b.pathResolve(&.{ "zig-pkg", pkg_hash });
 
     // The fetched path is a directory containing the extracted archive
     // Copy contents to our cache directory
-    var src_dir = b.graph.global_cache_root.handle.openDir(io, pkg_subpath, .{ .iterate = true }) catch |err| {
-        return step.fail("failed to open fetched directory 'p/{s}': {s}", .{ pkg_hash, @errorName(err) });
+    var src_dir = b.build_root.handle.openDir(io, pkg_subpath, .{ .iterate = true }) catch |err| {
+        return step.fail("failed to open fetched directory '{s}': {s}", .{ pkg_subpath, @errorName(err) });
     };
     defer src_dir.close(io);
 

--- a/HeadersStep.zig
+++ b/HeadersStep.zig
@@ -100,7 +100,7 @@ fn make(step: *Step, prog_node: Step.MakeOptions) !void {
     var args: [6][]const u8 = undefined;
     var arg_count: usize = 0;
 
-    args[arg_count] = godot_path;
+    args[arg_count] = b.pathFromRoot(godot_path);
     arg_count += 1;
 
     args[arg_count] = if (use_docs) "--dump-extension-api-with-docs" else "--dump-extension-api";
@@ -125,7 +125,7 @@ fn make(step: *Step, prog_node: Step.MakeOptions) !void {
         return step.fail("generated directory path not set", .{});
     var child = try std.process.spawn(io, .{
         .argv = args[0..arg_count],
-        .cwd = .{ .path = cwd_path },
+        .cwd = .{ .path = b.pathFromRoot(cwd_path) },
         .stderr = .ignore,
         .stdout = .ignore,
     });


### PR DESCRIPTION
- with Zig 0.16, fetched packages are now placed in the project directory, see
https://ziglang.org/download/0.16.0/release-notes.html#Fetch-Packages-Into-Project-Local-Directory
- generating the header files with the downloaded Godot executable was also giving me errors, so I used absolute paths for spawning this child process and that seemed to fix it